### PR TITLE
Fix /wordcount counting and speed up AO3 page fetches

### DIFF
--- a/commands/wordcount.js
+++ b/commands/wordcount.js
@@ -91,13 +91,47 @@ export default {
     },
 };
 
+// Word-counting logic ported from AO3's WordCounter (lib/word_counter.rb):
+// counts runs of word characters per text node, after normalizing dashes
+// and stripping apostrophes/hyphens, and counts CJK/Thai characters individually.
+const CHARACTER_COUNT_SCRIPTS = ['Han', 'Hiragana', 'Katakana', 'Thai'];
+const SCRIPT_PATTERN = CHARACTER_COUNT_SCRIPTS.map(script => `\\p{Script=${script}}`).join('|');
+const WORD_PATTERN = new RegExp(
+    `${SCRIPT_PATTERN}|(?:(?!${SCRIPT_PATTERN})[\\p{L}\\p{Nd}\\p{M}\\p{Pc}])+`,
+    'gu'
+);
+
+function countTextNodeWords(text) {
+    // -- becomes an emdash (so "one--two" still counts as 2 words), then
+    // apostrophes/hyphens are dropped (so "one-word" and "one's" count as 1 word)
+    const normalized = text.replace(/--/g, '—').replace(/['’‘-]/g, '');
+    return (normalized.match(WORD_PATTERN) || []).length;
+}
+
+// Recursively sum word counts across all text nodes, since AO3 counts each
+// text node independently (so markup splitting a word counts it twice)
+function countWords(element) {
+    let total = 0;
+    function traverse(node) {
+        if (node.type === 'text') {
+            total += countTextNodeWords(node.data);
+        } else if (node.children) {
+            node.children.forEach(traverse);
+        }
+    }
+    element.each((_, el) => traverse(el));
+    return total;
+}
+
 // Helper function to fetch word count for a single chapter
 async function fetchChapterWordCount(url, channelID) {
     try {
         const $ = await fetchDataWithHeaders(url, channelID);
         const article = $('div[role=article]');
-        const wordCount = article.text().trim().split(/\s+/).length;
-        return wordCount;
+        // Remove the "Chapter Text" landmark heading, which is part of the
+        // page template rather than the chapter content AO3 counts
+        article.find('h3.landmark.heading').remove();
+        return countWords(article);
     } catch (error) {
         console.error(`Error fetching chapter word count for ${url}: ${error}`);
         return 0; // Return 0 if there's an error

--- a/ficfeed.js
+++ b/ficfeed.js
@@ -33,23 +33,28 @@ export async function fetchDataWithHeaders(url, channelID, message) {
         msgText = `count for <${url}>`;
     }
     const headers = { 'User-Agent': 'ficfeed: link aggregating Discord bot developed by shantismurf@gmail.com' };
-    // send wait message silently...SuppressNotifications = 4096
-    let retryMessage = await feedChannel.send({ content: `Please wait. Processing ${msgText}`, flags: [4096] });
+    // wait message is only sent if a retry is needed, to avoid a Discord
+    // send+delete round trip on every successful fetch
+    let retryMessage = null;
     let retryCount = 0;
     let maxRetries = 5;
     let delay = 1000; // delay in milliseconds
     while (retryCount < maxRetries) {
         try {
-            const response = await axios.get(url, { headers });
+            const response = await axios.get(url, { headers, timeout: 20000 });
             const $ = cheerio.load(response.data);
-            // Delete the retry message after a successful fetch
+            // Delete the retry message if one was sent for an earlier failed attempt
             if (retryMessage) {
                 await retryMessage.delete();
                 console.log(`***Erased wait message at ${formattedDate()}`);
             }
             return $;
         } catch (error) {
-            const errorMessage = error.response?.data ? `${error.response.headers.server} ${error.response.status} error` : error.message.slice(0, 100); 
+            const errorMessage = error.response?.data ? `${error.response.headers.server} ${error.response.status} error` : error.message.slice(0, 100);
+            // send wait message silently...SuppressNotifications = 4096
+            if (!retryMessage) {
+                retryMessage = await feedChannel.send({ content: `Please wait. Processing ${msgText}`, flags: [4096] });
+            }
             // Update the retry message with the error
             if (error.response && error.response.headers['retry-after']) {
                 const retryAfter = parseInt(error.response.headers['retry-after']);


### PR DESCRIPTION
## Summary
- Port AO3's `WordCounter` algorithm (`lib/word_counter.rb`) into `/wordcount`'s chapter word-count logic, replacing the naive whitespace-split count. Verified exact matches against AO3's displayed word counts on both a single-chapter and a 19-chapter work (53,398 vs AO3's 53,398, previously 51,533).
- `fetchDataWithHeaders` no longer sends and immediately deletes a "Please wait" Discord message on every successful fetch — that message is now only sent if a retry is actually needed, cutting two unnecessary Discord API round trips per chapter fetched by `/wordcount`.
- Added a 20s axios timeout so a hanging AO3 response triggers the existing retry/backoff instead of stalling indefinitely.

## Test plan
- [x] Verified word counts against real AO3 pages (single-chapter and 19-chapter works) match AO3's official totals exactly
- [x] `node --check` passes on both modified files


---
_Generated by [Claude Code](https://claude.ai/code/session_014ds6rHoaBxeuDtdiRmXVot)_