### PR TITLE
Reconcile repo with production: drop YTD feature, sync prompt/deps/config

### DIFF
--- a/commands/prompt.js
+++ b/commands/prompt.js
@@ -1,42 +1,13 @@
 import { SlashCommandBuilder } from 'discord.js';
-
-const PROMPT_WORDS = [
-    // Atmosphere
-    'dawn', 'dusk', 'sunrise', 'sunset', 'sun', 'moon', 'stars', 'clouds',
-    'threshold', 'fog', 'ember', 'lantern', 'shadow', 'tide', 'ruins',
-    'hollow', 'dusk', 'labyrinth', 'cellar', 'crossroads', 'shoreline',
-    'attic', 'wilderness', 'archive', 'corridor', 'clearing', 'tower',
-
-    // Objects
-    'book', 'pen', 'pencil', 'paper', 'ink', 'inkwell', 'inkpot', 'quill', 
-    'mirror', 'anchor', 'clockwork', 'veil', 'key', 'compass', 'locket',
-    'manuscript', 'mask', 'wire', 'candle', 'map', 'lens', 'thread',
-    'photograph', 'sigil', 'relic', 'chain', 'parchment', 'scroll',
-    'potion', 'pouch', 'vial', 'ointment', 'gemstone', 'crystal',
-
-    // Abstract
-    'hollow', 'dusk', 'labyrinth', 'cellar', 'crossroads', 'shoreline',
-    'attic', 'wilderness', 'archive', 'corridor', 'clearing', 'lighthouse',
-    'hunger', 'fracture', 'silence', 'echo', 'longing', 'debt', 'mercy',
-    'grief', 'spite', 'wonder', 'dread', 'trust', 'betrayal', 'hope',
-    'obsession', 'surrender', 'guilt', 'pride',
-
-    // Nature   
-    'stone', 'water', 'fire', 'air', 'earth', 'light', 'darkness',
-    'rust', 'bloom', 'current', 'husk', 'marrow', 'spark', 'frost',
-    'ash', 'salt', 'root', 'storm', 'decay', 'growth', 'stone', 'smoke',
-
-    // Action
-    'whisper', 'chase', 'escape', 'search', 'capture', 'rescue', 
-    'pursuit', 'bargain', 'unraveling', 'vigil', 'return', 'vanishing', 
-    'reckoning', 'collision', 'inheritance', 'transformation', 'destruction',
-];
+import { readFile } from 'fs/promises';
 
 const HISTORY_SIZE = 25;
 const recentWords = [];
 
-function pickWord() {
-    const available = PROMPT_WORDS.filter(w => !recentWords.includes(w));
+async function pickWord() {
+    const raw = await readFile('./commands/promptWords.json', 'utf-8');
+    const words = Object.values(JSON.parse(raw)).flat();
+    const available = words.filter(w => !recentWords.includes(w));
     const word = available[Math.floor(Math.random() * available.length)];
 
     recentWords.push(word);
@@ -45,13 +16,15 @@ function pickWord() {
     return word;
 }
 
-export default {
+const command = {
     data: new SlashCommandBuilder()
         .setName('prompt')
         .setDescription('Get a single-word writing prompt'),
 
     async execute(interaction) {
-        const word = pickWord();
+        const word = await pickWord();
         await interaction.reply(`✍️ Your word is: **${word}**`);
     },
 };
+
+export default command;

--- a/commands/promptWords.json
+++ b/commands/promptWords.json
@@ -1,0 +1,45 @@
+{
+    "atmosphere": [
+        "dawn", "dusk", "sunrise", "sunset", "sun", "moon", "stars", "clouds",
+        "threshold", "fog", "ember", "lantern", "shadow", "tide", "ruins",
+        "hollow", "labyrinth", "cellar", "crossroads", "shoreline",
+        "attic", "wilderness", "archive", "corridor", "clearing", "tower"
+    ],
+
+    "objects": [
+        "book", "pen", "pencil", "paper", "ink", "inkwell", "inkpot", "quill",
+        "mirror", "anchor", "clockwork", "veil", "key", "compass", "locket",
+        "manuscript", "mask", "wire", "candle", "map", "lens", "thread",
+        "image", "sigil", "relic", "chain", "parchment", "scroll",
+        "potion", "pouch", "vial", "ointment", "gemstone", "crystal", "runes",
+        "bead", "braid", "clock", "box", "coin", "glasses", "tea pot", "helmet",
+        "belt", "key", "toy", "string", "spoon", "book", "comb", "knife", "chain"
+
+    ],
+
+    "abstract": [
+        "hunger", "fracture", "silence", "echo", "longing", "debt", "mercy",
+        "grief", "spite", "wonder", "dread", "trust", "betrayal", "hope",
+        "obsession", "surrender", "guilt", "pride", "madness", "history",
+        "confidence", "loyalty", "realize", "common", "poem", "honor",
+        "exceed", "contrast"
+    ],
+
+    "nature": [
+        "stone", "water", "fire", "air", "earth", "light", "darkness",
+        "rust", "bloom", "current", "husk", "marrow", "spark", "frost",
+        "ash", "salt", "root", "storm", "decay", "growth", "smoke",
+        "garden", "acorn", "mountain", "mushrooms",    "mouse",
+        "blossom", "freeze", "drift"
+    ],
+
+    "action": [
+        "whisper", "chase", "escape", "search", "capture", "rescue",
+        "pursuit", "bargain", "unraveling", "vigil", "return", "vanishing",
+        "reckoning", "collision", "inheritance", "transformation",
+        "destruction", "recovery", "journey", "protection", "courting",
+        "entertain", "bend", "fold", "routine", "rotate", "slap",
+        "dilute", "bind", "remark", "craft", "prevent", "fall",
+        "paint", "breathe", "repeat", "shop", "translate"
+    ]
+}

--- a/commands/wordcount.js
+++ b/commands/wordcount.js
@@ -91,13 +91,47 @@ export default {
     },
 };
 
+// Word-counting logic ported from AO3's WordCounter (lib/word_counter.rb):
+// counts runs of word characters per text node, after normalizing dashes
+// and stripping apostrophes/hyphens, and counts CJK/Thai characters individually.
+const CHARACTER_COUNT_SCRIPTS = ['Han', 'Hiragana', 'Katakana', 'Thai'];
+const SCRIPT_PATTERN = CHARACTER_COUNT_SCRIPTS.map(script => `\\p{Script=${script}}`).join('|');
+const WORD_PATTERN = new RegExp(
+    `${SCRIPT_PATTERN}|(?:(?!${SCRIPT_PATTERN})[\\p{L}\\p{Nd}\\p{M}\\p{Pc}])+`,
+    'gu'
+);
+
+function countTextNodeWords(text) {
+    // -- becomes an emdash (so "one--two" still counts as 2 words), then
+    // apostrophes/hyphens are dropped (so "one-word" and "one's" count as 1 word)
+    const normalized = text.replace(/--/g, '—').replace(/['’‘-]/g, '');
+    return (normalized.match(WORD_PATTERN) || []).length;
+}
+
+// Recursively sum word counts across all text nodes, since AO3 counts each
+// text node independently (so markup splitting a word counts it twice)
+function countWords(element) {
+    let total = 0;
+    function traverse(node) {
+        if (node.type === 'text') {
+            total += countTextNodeWords(node.data);
+        } else if (node.children) {
+            node.children.forEach(traverse);
+        }
+    }
+    element.each((_, el) => traverse(el));
+    return total;
+}
+
 // Helper function to fetch word count for a single chapter
 async function fetchChapterWordCount(url, channelID) {
     try {
         const $ = await fetchDataWithHeaders(url, channelID);
         const article = $('div[role=article]');
-        const wordCount = article.text().trim().split(/\s+/).length;
-        return wordCount;
+        // Remove the "Chapter Text" landmark heading, which is part of the
+        // page template rather than the chapter content AO3 counts
+        article.find('h3.landmark.heading').remove();
+        return countWords(article);
     } catch (error) {
         console.error(`Error fetching chapter word count for ${url}: ${error}`);
         return 0; // Return 0 if there's an error

--- a/config.json.template
+++ b/config.json.template
@@ -8,6 +8,5 @@
   "GUILD": "your_guild_id_here",
   "CLIENTID": "your_client_id_here",
   "TESTCLIENTID": "your_testclient_id_here",
-  "ARCHIVESTATSCHANNEL": "your_archivestats_channel_id_here",
   "TESTENVIRONMENT": "Must be TRUE or FALSE"
 }

--- a/ficfeed.js
+++ b/ficfeed.js
@@ -33,23 +33,28 @@ export async function fetchDataWithHeaders(url, channelID, message) {
         msgText = `count for <${url}>`;
     }
     const headers = { 'User-Agent': 'ficfeed: link aggregating Discord bot developed by shantismurf@gmail.com' };
-    // send wait message silently...SuppressNotifications = 4096
-    let retryMessage = await feedChannel.send({ content: `Please wait. Processing ${msgText}`, flags: [4096] });
+    // wait message is only sent if a retry is needed, to avoid a Discord
+    // send+delete round trip on every successful fetch
+    let retryMessage = null;
     let retryCount = 0;
     let maxRetries = 5;
     let delay = 1000; // delay in milliseconds
     while (retryCount < maxRetries) {
         try {
-            const response = await axios.get(url, { headers });
+            const response = await axios.get(url, { headers, timeout: 20000 });
             const $ = cheerio.load(response.data);
-            // Delete the retry message after a successful fetch
+            // Delete the retry message if one was sent for an earlier failed attempt
             if (retryMessage) {
                 await retryMessage.delete();
                 console.log(`***Erased wait message at ${formattedDate()}`);
             }
             return $;
         } catch (error) {
-            const errorMessage = error.response?.data ? `${error.response.headers.server} ${error.response.status} error` : error.message.slice(0, 100); 
+            const errorMessage = error.response?.data ? `${error.response.headers.server} ${error.response.status} error` : error.message.slice(0, 100);
+            // send wait message silently...SuppressNotifications = 4096
+            if (!retryMessage) {
+                retryMessage = await feedChannel.send({ content: `Please wait. Processing ${msgText}`, flags: [4096] });
+            }
             // Update the retry message with the error
             if (error.response && error.response.headers['retry-after']) {
                 const retryAfter = parseInt(error.response.headers['retry-after']);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,44 +10,35 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.7",
-        "axios-cookiejar-support": "^6.0.5",
         "cheerio": "^1.0.0",
-        "discord.js": "^14.16.3",
+        "discord.js": "^14.25.1",
         "dotenv": "^16.4.5",
-        "glob": "^11.0.1",
-        "tough-cookie": "^6.0.0"
+        "glob": "^11.0.1"
       },
       "devDependencies": {
-        "eslint": "^9.14.0",
-        "node-cron": "^4.2.1"
+        "eslint": "^9.39.4"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.9.0.tgz",
-      "integrity": "sha512-0zx8DePNVvQibh5ly5kCEei5wtPBIUbSoE9n+91Rlladz4tgtFbJ36PZMxxZrTEOQ7AHMZ/b0crT/0fCy6FTKg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/formatters": "^0.5.0",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
         "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "0.37.97",
+        "discord-api-types": "^0.38.40",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.4",
         "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.11.0"
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.37.97",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
-      "integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA==",
-      "license": "MIT"
     },
     "node_modules/@discordjs/collection": {
       "version": "1.5.3",
@@ -59,41 +50,35 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.5.0.tgz",
-      "integrity": "sha512-98b3i+Y19RFq1Xke4NkVY46x8KjJQjldHUuEbCqMvp1F5Iq9HgnGpu91jOi/Ufazhty32eRsKnnzS8n4c+L93g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "discord-api-types": "0.37.97"
+        "discord-api-types": "^0.38.33"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.11.0"
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-      "version": "0.37.97",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
-      "integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA==",
-      "license": "MIT"
-    },
     "node_modules/@discordjs/rest": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0.tgz",
-      "integrity": "sha512-Xb2irDqNcq+O8F0/k/NaDp7+t091p+acb51iA4bCKfIn+WFWd6HrNvcsSbMMxIR9NjcMZS6NReTKygqiQN+ntw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/util": "^1.2.0",
         "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
+        "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "0.37.97",
-        "magic-bytes.js": "^1.10.0",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.19.8"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -114,17 +99,24 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
-      "version": "0.37.97",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
-      "integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA==",
-      "license": "MIT"
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
-      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -133,20 +125,20 @@
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
-      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.3.0",
+        "@discordjs/rest": "^2.5.1",
         "@discordjs/util": "^1.1.0",
         "@sapphire/async-queue": "^1.5.2",
         "@types/ws": "^8.5.10",
         "@vladfrangu/async_event_emitter": "^2.2.4",
-        "discord-api-types": "0.37.83",
+        "discord-api-types": "^0.38.1",
         "tslib": "^2.6.2",
-        "ws": "^8.16.0"
+        "ws": "^8.17.0"
       },
       "engines": {
         "node": ">=16.11.0"
@@ -167,16 +159,10 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
-      "version": "0.37.83",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
-      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==",
-      "license": "MIT"
-    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -216,45 +202,61 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -265,19 +267,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -285,12 +290,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -350,9 +356,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -428,27 +434,27 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
-      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
       "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
@@ -456,9 +462,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -478,19 +484,10 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -555,60 +552,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios-cookiejar-support": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-6.0.5.tgz",
-      "integrity": "sha512-ldPOQCJWB0ipugkTNVB8QRl/5L2UgfmVNVQtS9en1JQJ1wW588PqAmymnwmmgc12HLDzDtsJ28xE2ppj4rD4ng==",
-      "license": "MIT",
-      "dependencies": {
-        "http-cookie-agent": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/3846masa"
-      },
-      "peerDependencies": {
-        "axios": ">=0.20.0",
-        "tough-cookie": ">=4.0.0"
-      }
-    },
-    "node_modules/axios-cookiejar-support/node_modules/http-cookie-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.3.tgz",
-      "integrity": "sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.4"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/3846masa"
-      },
-      "peerDependencies": {
-        "tough-cookie": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "undici": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "undici": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/axios-cookiejar-support/node_modules/undici": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.0.tgz",
-      "integrity": "sha512-CfPufgPFHCYu0W4h1NiKW9+tNJ39o3kWm7Cm29ET1enSJx+AERfz7A2wAr26aY0SZbYzZlTBQtcHy15o60VZfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -622,9 +565,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -752,9 +695,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -794,9 +737,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -828,29 +771,33 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.100",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.100.tgz",
-      "integrity": "sha512-a8zvUI0GYYwDtScfRd/TtaNBDTXwP5DiDVX7K5OmE+DRT57gBqKnwtOC5Ol8z0mRW8KQfETIgiB8U0YZ9NXiCA==",
-      "license": "MIT"
+      "version": "0.38.48",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.48.tgz",
+      "integrity": "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/discord.js": {
-      "version": "14.16.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.3.tgz",
-      "integrity": "sha512-EPCWE9OkA9DnFFNrO7Kl1WHHDYFXu3CNVFJg63bfU7hVtjZGyhShwZtSBImINQRWxWP2tgo2XI+QhdXx28r0aA==",
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.9.0",
+        "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.5.0",
-        "@discordjs/rest": "^2.4.0",
-        "@discordjs/util": "^1.1.1",
-        "@discordjs/ws": "1.1.1",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "0.37.100",
+        "discord-api-types": "^0.38.40",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.19.8"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -1036,32 +983,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.7.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.14.0",
-        "@eslint/plugin-kit": "^0.2.0",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.0",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1073,10 +1020,9 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -1097,9 +1043,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1114,9 +1060,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1127,15 +1073,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1535,9 +1481,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1615,10 +1561,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1689,9 +1645,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -1717,9 +1673,9 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
-      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1753,9 +1709,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1787,16 +1743,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-cron": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
-      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -2148,43 +2094,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tldts": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
-      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.0.19"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
-      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
-      "license": "MIT"
-    },
-    "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -2211,18 +2120,18 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -2370,9 +2279,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -12,15 +12,12 @@
   "description": "",
   "dependencies": {
     "axios": "^1.7.7",
-    "axios-cookiejar-support": "^6.0.5",
     "cheerio": "^1.0.0",
-    "discord.js": "^14.16.3",
+    "discord.js": "^14.25.1",
     "dotenv": "^16.4.5",
-    "glob": "^11.0.1",
-    "tough-cookie": "^6.0.0"
+    "glob": "^11.0.1"
   },
   "devDependencies": {
-    "eslint": "^9.14.0",
-    "node-cron": "^4.2.1"
+    "eslint": "^9.39.4"
   }
 }

--- a/tracker.js
+++ b/tracker.js
@@ -1,0 +1,100 @@
+import { db } from './utilities.js';
+
+export async function createTable(tableName, columns) {
+    const createTableQuery = `CREATE TABLE IF NOT EXISTS ${tableName} (${columns})`;
+    await db.query(createTableQuery);
+}
+
+await createTable('tracker', `
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id VARCHAR(50) NOT NULL,
+    work_id VARCHAR(32) NOT NULL,
+    status ENUM('to read', 'reading', 'finished') DEFAULT 'to read',
+    date_added DATETIME DEFAULT CURRENT_TIMESTAMP,
+    date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    work_title VARCHAR(255),
+    author_name VARCHAR(255),
+    last_chapter_read INT DEFAULT 0,
+    notes TEXT
+`);
+
+await createTable('series', `
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    series_id VARCHAR(255) NOT NULL,
+    series_title VARCHAR(255) NOT NULL
+`);
+
+await createTable('collections', `
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    collection_name VARCHAR(255) NOT NULL,
+    collection_title VARCHAR(255) NOT NULL
+`);
+
+await createTable('work_series', `
+    work_id VARCHAR(255) NOT NULL,
+    series_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (work_id, series_id)
+`);
+
+await createTable('work_collection', `
+    work_id VARCHAR(255) NOT NULL,
+    collection_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (work_id, collection_id)
+`);
+
+// Add AO3 link to user's list
+export async function trackAo3Link(userId, workUrl, status = 'to read', workTitle = '', authorName = '') {
+    await db.execute(
+        `INSERT INTO tracker (user_id, work_url, status, work_title, author_name)
+         VALUES (?, ?, ?, ?, ?)`,
+        [userId, workUrl, status, workTitle, authorName]
+    );
+}
+
+// List all tracked links for a user
+export async function listAo3Links(userId, { search, status, startDate, endDate } = {}) {
+    let query = `SELECT work_url, status, work_title, author_name, last_chapter_read, notes, date_added
+                 FROM tracker WHERE user_id = ?`;
+    const params = [userId];
+
+    if (search) {
+        query += ` AND (work_title LIKE ? OR author_name LIKE ? OR notes LIKE ? OR tags LIKE ?)`;
+        params.push(`%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`);
+    }
+    if (status) {
+        query += ` AND status = ?`;
+        params.push(status);
+    }
+    if (startDate) {
+        query += ` AND (date_added >= ? OR (status = 'finished' AND date_updated >= ?))`;
+        params.push(startDate, startDate);
+    }
+    if (endDate) {
+        query += ` AND (date_added <= ? OR (status = 'finished' AND date_updated <= ?))`;
+        params.push(endDate, endDate);
+    }
+    query += ` ORDER BY date_added DESC`;
+
+    const [rows] = await db.execute(query, params);
+    return rows;
+}
+
+// Update status, last chapter, or notes
+export async function updateAo3Link(userId, workUrl, { status, lastChapterRead, notes }) {
+    await db.execute(
+        `UPDATE tracker SET
+            status = COALESCE(?, status),
+            last_chapter_read = COALESCE(?, last_chapter_read),
+            notes = COALESCE(?, notes)
+         WHERE user_id = ? AND work_url = ?`,
+        [status, lastChapterRead, notes, userId, workUrl]
+    );
+}
+
+// Remove a link from user's list
+export async function untrackAo3Link(userId, workUrl) {
+    await db.execute(
+        `DELETE FROM tracker WHERE user_id = ? AND work_url = ?`,
+        [userId, workUrl]
+    );
+}

--- a/utilities.js
+++ b/utilities.js
@@ -70,7 +70,7 @@ export function userStats() {
     Tags may be up to 100 characters long and can include characters from most languages, numbers, spaces, and some punctuation.
     */
     let userStats = {};
-    userStats.processAdultLinks = 2;
+    userStats.processAdultLinks = 1;
     //processAdultLinks: 
     // 1 = post all links to the regular feedChannel, 
     // 2 = post adult links to both the regular channel and the adult channel, 
@@ -103,104 +103,3 @@ export class DiscordClient { // Create a new client instance
         return DiscordClient.instance;
     }
 }
-/*
-import cron from 'node-cron';
-// Schedule a task to run on the 1st and 15th at midnight CST
-//cron.schedule('0 0 1,15 * *', async () => {
-cron.schedule('50 15 5 1 *', async () => {
-    console.log(`***Running fic count task at ${formattedDate()}`);
-    await YTDficCount();
-    console.log(`***Finished fic count task at ${formattedDate()}`);
-}, {
-  scheduled: true,
-  timezone: "America/Chicago"
-});
-*/
-const ArchiveStatsChannel = config.ARCHIVESTATSCHANNEL;
-const client = DiscordClient.getInstance();
-import { fetchDataWithHeaders } from './ficfeed.js';
-
-function getPercentYearLeft() {
-    const now = new Date();
-    const currentYear = now.getFullYear();
-    // Set the start of the current year (January 1st, 00:00:00)
-    const yearStart = new Date(currentYear, 0, 1);
-    // Set the end of the current year (January 1st of next year, 00:00:00)
-    const yearEnd = new Date(currentYear + 1, 0, 1);
-    // Calculate total milliseconds in the year
-    const totalMillisecondsInYear = yearEnd - yearStart;
-    // Calculate milliseconds remaining in the year
-    const remainingMilliseconds = yearEnd - now;
-    // Calculate and return the percentage left as decimal
-	const PercentYearLeft = 1 - (remainingMilliseconds / totalMillisecondsInYear);
-	return PercentYearLeft; 
-}
-
-async function YTDficCount() { 
-    const now = new Date();
-    const curYear = now.getFullYear();
-    const curDate = now.toLocaleDateString('en-US');
-    let searchURL = {};
-    const base =
-        `https://archiveofourown.org/works?` +
-        `work_search%5Bquery%5D=created_at%3A%5B%22${curYear}-01-01%22+TO+%22${curYear}-12-31%22%5D` +
-        `&tag_id=Bilbo+Baggins*s*Thorin+Oakenshield`;
-    searchURL.AllYTD = base;
-    searchURL.CompleteYTD = `${base}&work_search%5Bcomplete%5D=T`;
-    searchURL.AllEngYTD = `${base}&work_search%5Blanguage_id%5D=en`;
-    searchURL.EngCompleteYTD = `${base}&work_search%5Bcomplete%5D=T&work_search%5Blanguage_id%5D=en`;
-    searchURL.podficYTD = `${base}&work_search%5Bother_tag_names%5D=Podfic`;
-    const ranges = [
-        [0, 10000],
-        [10001, 30000],
-        [30001, 60000],
-        [60001, 100000],
-        [100001, 1000000]
-        ];
-    for (const [wordsFrom, wordsTo] of ranges) {
-        const key = `wc${wordsFrom}to${wordsTo}`;
-        searchURL[key] = base + '&work_search%5Bwords_from%5D=' + wordsFrom + '&work_search%5Bwords_to%5D=' + wordsTo;
-    }
-    const [
-        AllYTD,
-        CompleteYTD,
-        AllEngYTD,
-        EngCompleteYTD,
-        PodficYTD,
-        wc0to10000, 
-        wc10001to30000, 
-        wc30001to60000, 
-        wc60001to100000, 
-        wc100001to1000000
-    ] = await Promise.all([
-        getSearchCount(searchURL.AllYTD),
-        getSearchCount(searchURL.CompleteYTD),
-        getSearchCount(searchURL.AllEngYTD),
-        getSearchCount(searchURL.EngCompleteYTD),
-        getSearchCount(searchURL.podficYTD),
-        getSearchCount(searchURL.wc0to10000),
-        getSearchCount(searchURL.wc10001to30000),
-        getSearchCount(searchURL.wc30001to60000),
-        getSearchCount(searchURL.wc60001to100000),
-        getSearchCount(searchURL.wc100001to1000000)
-    ]);
-
-    const pctComplete = ((CompleteYTD/AllYTD) * 100).toFixed(2) + "%";
-    const pctNonEnglish = ((1 - (AllEngYTD/AllYTD)) * 100).toFixed(2) + "%";
-    let pctPartialYear = getPercentYearLeft();
-    const ProjectedTotal = (AllYTD/pctPartialYear).toFixed(0);
-    pctPartialYear = (pctPartialYear * 100).toFixed(2) + "%";
-
-    const txtHeaderColumns = 'Date, Total, Complete, English, English Complete, Podfics, % Complete, % Non-English, Partial Year %, Projected Total, (skip and calculate in spreadsheet: Percent change, vs Last Year Total, Posts/Day,) 0-10000, 10001-30000, 30001-60000, 60001-100000, 100001-1000000'
-    const msgForFeed = txtHeaderColumns + `\n\`\`\`${curDate}\t${AllYTD}\t${CompleteYTD}\t${AllEngYTD}\t${EngCompleteYTD}\t${PodficYTD}\t${pctComplete}\t${pctNonEnglish}\t${pctPartialYear}\t${ProjectedTotal}\t\t\t\t${wc0to10000}\t${wc10001to30000}\t${wc30001to60000}\t${wc60001to100000}\t${wc100001to1000000}\`\`\``;
-
-    await client.channels.cache.get(ArchiveStatsChannel).send(msgForFeed);
-}
-
-async function getSearchCount(url) {
-    const $ = await fetchDataWithHeaders(url,ArchiveStatsChannel);
-    const headingText = $('h2.heading').first().text();
-    const match = headingText.match(/([\d,]+)\s+Works/i); // "1 - 20 of 933 Works found in Bilbo Baggins/Thorin Oakenshield" or "14 Works found in Bilbo Baggins/Thorin Oakenshield"
-    const totalWorkCount = match ? parseInt(match[1].replace(/,/g, ''), 10): 0;
-    return totalWorkCount;
-}   


### PR DESCRIPTION
## Summary
Reconciles `main` with the production codebase (everything except the wordcount/ficfeed fixes already on this branch), per the file-by-file comparison done earlier in this session:

- **Remove defunct YTD fic-count feature** from `utilities.js` (cron job, `getPercentYearLeft`, `YTDficCount`, `getSearchCount`, `ArchiveStatsChannel`, and unused `node-cron`/`fetchDataWithHeaders` imports). The YTD process now runs separately via a Tampermonkey script and this code was no longer used. Also restores `userStats.processAdultLinks = 1` to match production.
- **Adopt production's `/prompt` refactor**: word list moved to new `commands/promptWords.json`, `pickWord()` is now async, and the word list is the deduplicated/expanded version already running on production.
- **Add `tracker.js`** (production's reading-tracker DB helpers), present on production but missing from the repo. Still unwired/unused, matching production's current state.
- **Sync dependencies with production**: bump `discord.js` to `^14.25.1` and `eslint` to `^9.39.4`; drop unused `axios-cookiejar-support`, `tough-cookie`, and `node-cron`.
- **`config.json.template`**: remove the now-dead `ARCHIVESTATSCHANNEL` entry.

`commands/wordcount.js`, `ficfeed.js` (this branch's wordcount/efficiency fixes), and `index.js` (permission-check feature) are unchanged.

## Test plan
- [x] `node --check` on all modified/added JS files
- [x] `npm install` to regenerate `package-lock.json`
- [ ] Deploy to production and confirm bot starts and commands load


---
_Generated by [Claude Code](https://claude.ai/code/session_014ds6rHoaBxeuDtdiRmXVot)_